### PR TITLE
Fix tree collision check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## collision.js
+### 🛠 Changed
+- 062425-1958 Exclude tree objects from collision checks and remove special-case handling.

--- a/js/collision.js
+++ b/js/collision.js
@@ -2,10 +2,10 @@ import * as THREE from 'three';
 import { terrainGenerator, getGroundHeight } from './worldGeneration.js';
 
 // Return array of meshes that should be used for collision checks
+// Trees were previously included but no longer participate in collisions
 export function getCollidableMeshes(scene) {
-  return scene.children.filter(child =>
-    child.userData.isBlock || child.userData.isBarrier ||
-    (child.type === 'Group' && child.userData.isTree)
+  return scene.children.filter(
+    child => (child.userData.isBlock || child.userData.isBarrier) && !child.userData.isTree
   );
 }
 
@@ -61,11 +61,7 @@ export function resolvePlayerMovement(pos, movement, velocity, scene, options = 
   }
 
   blocks.forEach(block => {
-    if (block.type === 'Group' && block.userData.isTree) {
-      checkBlock(block, 1.0, 2.0, 1.0);
-    } else {
-      checkBlock(block);
-    }
+    checkBlock(block);
   });
 
   const groundHeight = getGroundHeight(newX, newZ, scene);


### PR DESCRIPTION
## Summary
- exclude tree objects from collision checks
- simplify block collision loop
- document change in CHANGELOG

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685b0316b40083329f26cdb9c666568c