### PR TITLE
Display changelog modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,15 @@
 ## assets
 ### 🔥 Removed
 - 062425-2005 Drop unused pine_tree.glb model.
+
+## changelogModal.js
+### ✨ Added
+- 062425-2013 Display CHANGELOG in a modal on page load.
+
+## index.html
+### ✨ Added
+- 062425-2013 Include changelog modal markup and script.
+
+## styles.css
+### ✨ Added
+- 062425-2013 Style rules for changelog modal overlay.

--- a/css/styles.css
+++ b/css/styles.css
@@ -489,6 +489,41 @@ body {
   }
   
   .instructions {
-    display: none !important; 
+    display: none !important;
   }
+}
+
+#changelog-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 3000;
+}
+
+#changelog-modal .modal-content {
+  background: #222;
+  color: #fff;
+  padding: 20px;
+  max-width: 80%;
+  max-height: 80%;
+  overflow: auto;
+  border-radius: 8px;
+  position: relative;
+}
+
+#changelog-modal .changelog-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 24px;
+  cursor: pointer;
 }

--- a/index.html
+++ b/index.html
@@ -34,6 +34,12 @@
       </div>
     </div>
   </div>
+  <div id="changelog-modal" style="display:none;">
+    <div class="modal-content">
+      <button class="changelog-close">&times;</button>
+      <pre class="changelog-content"></pre>
+    </div>
+  </div>
   <div id="loading-screen" style="display: none;">
     <div class="loading-content">
       <h2 id="loading-message">Loading World...</h2>
@@ -82,6 +88,7 @@
     </div>
   </div>
 
+  <script type="module" src="js/changelogModal.js"></script>
   <script src="js/app.js" type="module"></script>
 </body>
 </html>

--- a/js/changelogModal.js
+++ b/js/changelogModal.js
@@ -1,0 +1,31 @@
+// Fetches CHANGELOG.md and displays it in a modal
+
+async function initChangelogModal() {
+  const modal = document.getElementById('changelog-modal');
+  if (!modal) return;
+  const closeBtn = modal.querySelector('.changelog-close');
+  const contentEl = modal.querySelector('.changelog-content');
+
+  // Close handler
+  closeBtn.addEventListener('click', () => {
+    modal.style.display = 'none';
+  });
+
+  try {
+    const res = await fetch('CHANGELOG.md');
+    const text = await res.text();
+    contentEl.textContent = text;
+  } catch (err) {
+    contentEl.textContent = 'Failed to load changelog.';
+  }
+
+  modal.style.display = 'flex';
+}
+
+if (document.readyState !== 'loading') {
+  initChangelogModal();
+} else {
+  document.addEventListener('DOMContentLoaded', initChangelogModal);
+}
+
+export {}; // module indicator


### PR DESCRIPTION
## Summary
- fetch and show changelog in modal
- add changelog modal markup
- style modal overlay
- load new changelog script
- document changelog modal feature

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685b0668c58083329179877a8670f056