### PR TITLE
Add fox NPC wandering feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### 🔥 Removed
 - 062425-2001 Omit createTrees import and usage; drop related loading message.
 
+### ✨ Added
+- 062425-2017 Spawn fox NPCs and update animation loop for movement.
+
 ## assets
 ### 🔥 Removed
 - 062425-2005 Drop unused pine_tree.glb model.
@@ -23,3 +26,8 @@
 ## styles.css
 ### ✨ Added
 - 062425-2013 Style rules for changelog modal overlay.
+
+## fox.js
+### ✨ Added
+- 062425-2017 Add roaming fox NPCs with walking animation.
+

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,9 @@
 import * as THREE from "three";
 import { PlayerControls } from "./controls.js";
 import { createPlayerModel, changeAnimation } from "./player.js";
-import { createBarriers, createTerrain } from "./worldGeneration.js";
+import { createBarriers, createTerrain, getGroundHeight } from "./worldGeneration.js";
 import { createSkybox } from "./skybox.js";
+import { spawnFoxes } from "./fox.js";
 
 // Simple seeded random number generator
 class MathRandom {
@@ -111,6 +112,9 @@ async function main() {
     // Create terrain and natural features
     createBarriers(scene);
     createTerrain(scene);
+
+    // Spawn wandering foxes
+    const foxes = await spawnFoxes(scene, 12);
     
     const renderer = new THREE.WebGLRenderer({ antialias: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
@@ -417,6 +421,19 @@ async function main() {
           } else {
             playerLabels[clientId].style.display = 'none';
           }
+        }
+      }
+
+      // Move and animate foxes
+      for (const fox of foxes) {
+        fox.userData.mixer.update(0.016);
+        fox.position.addScaledVector(fox.userData.direction, fox.userData.speed);
+        fox.position.y = getGroundHeight(fox.position.x, fox.position.z, scene);
+        fox.rotation.y = Math.atan2(fox.userData.direction.x, fox.userData.direction.z);
+        if (Math.random() < 0.01) {
+          fox.userData.direction.x += (Math.random() - 0.5) * 0.5;
+          fox.userData.direction.z += (Math.random() - 0.5) * 0.5;
+          fox.userData.direction.normalize();
         }
       }
       

--- a/js/fox.js
+++ b/js/fox.js
@@ -1,0 +1,46 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { getGroundHeight } from './worldGeneration.js';
+
+function loadGLTF(loader, url) {
+  return new Promise((resolve, reject) => {
+    loader.load(url, resolve, undefined, reject);
+  });
+}
+
+export async function spawnFoxes(scene, count) {
+  const loader = new GLTFLoader();
+  const [foxGltf, walkGltf] = await Promise.all([
+    loadGLTF(loader, 'assets/models/fox.glb'),
+    loadGLTF(loader, 'assets/models/fox_walking_animation.glb')
+  ]);
+
+  const foxes = [];
+  for (let i = 0; i < count; i++) {
+    const fox = foxGltf.scene.clone(true);
+    fox.traverse(child => {
+      if (child.isMesh) {
+        child.castShadow = true;
+        child.receiveShadow = true;
+      }
+    });
+
+    const mixer = new THREE.AnimationMixer(fox);
+    const action = mixer.clipAction(walkGltf.animations[0]);
+    action.play();
+
+    const x = (Math.random() * 40) - 20;
+    const z = (Math.random() * 40) - 20;
+    const y = getGroundHeight(x, z, scene);
+    fox.position.set(x, y, z);
+
+    fox.userData.mixer = mixer;
+    fox.userData.direction = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
+    fox.userData.speed = 0.02 + Math.random() * 0.02;
+
+    scene.add(fox);
+    foxes.push(fox);
+  }
+
+  return foxes;
+}


### PR DESCRIPTION
## Summary
- create `fox.js` for loading fox model and walking animation
- spawn 12 animated foxes in `app.js`
- animate foxes each frame with simple wandering logic
- document new fox NPC feature in `CHANGELOG.md`

## Testing
- `node --check js/fox.js`
- `node --check js/app.js`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685b073a1ea08332b029ade344c5f0f0