### PR TITLE
Add pulsing LT logo to intro screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@
 ## index.html
 ### ✨ Added
 - 062425-2013 Include changelog modal markup and script.
+- 062425-2038 ui/intro-screen: Pulsing LT logo next to title.
 
 ## styles.css
 ### ✨ Added
 - 062425-2013 Style rules for changelog modal overlay.
+- 062425-2038 ui/intro-screen: Animations for LT logo and layout tweaks.
 
 ## fox.js
 ### ✨ Added

--- a/css/styles.css
+++ b/css/styles.css
@@ -229,19 +229,47 @@ body {
   z-index: 2000;
 }
 
+#intro-screen .title-container {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 40px;
+}
+
 #intro-screen h1 {
   font-size: 72px;
   color: #fff;
-  text-shadow: 
-    -2px -2px 0 #000,  
+  text-shadow:
+    -2px -2px 0 #000,
      2px -2px 0 #000,
     -2px  2px 0 #000,
      2px  2px 0 #000,
      0 0 20px rgba(255, 255, 255, 0.5);
-  margin-bottom: 40px;
+  margin: 0;
   font-family: 'Arial Black', sans-serif;
   letter-spacing: 4px;
   animation: glow 2s ease-in-out infinite alternate;
+}
+
+.lt-logo {
+  width: 64px;
+  height: 64px;
+  animation: logo-pulse 2s infinite;
+}
+
+@keyframes logo-pulse {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 #intro-screen h1 span {

--- a/index.html
+++ b/index.html
@@ -15,9 +15,12 @@
   <script src="https://cdn.jsdelivr.net/npm/nipplejs@0.10.1/dist/nipplejs.min.js"></script>
 </head>
 <body>
-  <div id="intro-screen">
-    <h1><span>Z</span>1 Survive</h1>
-    <button id="enter-button">ENTER WORLD</button>
+    <div id="intro-screen">
+      <div class="title-container">
+        <img src="assets/lt/ltcontrib.png" alt="LT Contributor Logo" class="lt-logo">
+        <h1><span>Z</span>1 Survive</h1>
+      </div>
+      <button id="enter-button">ENTER WORLD</button>
     
     <!-- Add support section -->
     <div class="support-section">


### PR DESCRIPTION
## Summary
- add an LT contributor logo image next to the Z1 title
- animate the logo with a pulse effect
- document the change in the changelog

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685b0c4f564883329e475115c8e184f6