### PR TITLE
Add button to open changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@
 ## changelogModal.js
 ### ✨ Added
 - 062425-2013 Display CHANGELOG in a modal on page load.
+### 🛠 Changed
+- 062425-2050 Open changelog via button instead of automatically.
 
 ## index.html
 ### ✨ Added
 - 062425-2013 Include changelog modal markup and script.
 - 062425-2038 ui/intro-screen: Pulsing LT logo next to title.
+- 062425-2050 ui/intro-screen: Changelog button below Enter World.
 
 ## styles.css
 ### ✨ Added
@@ -31,6 +34,7 @@
 - 062425-2038 ui/intro-screen: Animations for LT logo and layout tweaks.
 ### 🛠 Changed
 - 062425-2043 ui/intro-screen: Enlarged LT logo to 3x size.
+- 062425-2050 ui/intro-screen: Styling for changelog button.
 
 ## fox.js
 ### ✨ Added

--- a/css/styles.css
+++ b/css/styles.css
@@ -295,6 +295,26 @@ body {
   box-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
 }
 
+#changelog-button {
+  margin-top: 10px;
+  padding: 12px 24px;
+  font-size: 18px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border: 2px solid #fff;
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+  letter-spacing: 2px;
+}
+
+#changelog-button:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+  transform: scale(1.05);
+  box-shadow: 0 0 20px rgba(255, 255, 255, 0.3);
+}
+
 @keyframes glow {
   from {
     text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);

--- a/index.html
+++ b/index.html
@@ -20,7 +20,9 @@
         <img src="assets/lt/ltcontrib.png" alt="LT Contributor Logo" class="lt-logo">
         <h1><span>Z</span>1 Survive</h1>
       </div>
+
       <button id="enter-button">ENTER WORLD</button>
+      <button id="changelog-button">CHANGELOG</button>
     
     <!-- Add support section -->
     <div class="support-section">

--- a/js/changelogModal.js
+++ b/js/changelogModal.js
@@ -1,31 +1,39 @@
-// Fetches CHANGELOG.md and displays it in a modal
+// Handles displaying the CHANGELOG in a modal when requested
 
-async function initChangelogModal() {
+function setupChangelogModal() {
   const modal = document.getElementById('changelog-modal');
-  if (!modal) return;
+  const button = document.getElementById('changelog-button');
+  if (!modal || !button) return;
+
   const closeBtn = modal.querySelector('.changelog-close');
   const contentEl = modal.querySelector('.changelog-content');
+  let loaded = false;
 
-  // Close handler
+  async function openModal() {
+    if (!loaded) {
+      try {
+        const res = await fetch('CHANGELOG.md');
+        const text = await res.text();
+        contentEl.textContent = text;
+      } catch (err) {
+        contentEl.textContent = 'Failed to load changelog.';
+      }
+      loaded = true;
+    }
+    modal.style.display = 'flex';
+  }
+
   closeBtn.addEventListener('click', () => {
     modal.style.display = 'none';
   });
 
-  try {
-    const res = await fetch('CHANGELOG.md');
-    const text = await res.text();
-    contentEl.textContent = text;
-  } catch (err) {
-    contentEl.textContent = 'Failed to load changelog.';
-  }
-
-  modal.style.display = 'flex';
+  button.addEventListener('click', openModal);
 }
 
 if (document.readyState !== 'loading') {
-  initChangelogModal();
+  setupChangelogModal();
 } else {
-  document.addEventListener('DOMContentLoaded', initChangelogModal);
+  document.addEventListener('DOMContentLoaded', setupChangelogModal);
 }
 
 export {}; // module indicator


### PR DESCRIPTION
## Summary
- add a "Changelog" button under the intro screen
- style changelog button to match the "Enter World" button
- load the changelog when the new button is clicked

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685b0eed77d48332a2e153493d2d95bc