### PR TITLE
Improve fox performance by removing raycasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,14 @@
 - 062425-2017 Add roaming fox NPCs with walking animation.
 ### 🐛 Fixed
 - 062425-2123 Fix incorrect GLB path for roaming fox model.
+### 🛠 Changed
+- 062425-2155 Use noise-based ground height lookup to reduce raycasting.
 
 ## worldGeneration.js
 ### 🔥 Removed
 - 062425-2021 Delete unused MathRandom class.
+### 🛠 Changed
+- 062425-2155 Replace raycaster height queries with direct noise lookup.
 
 ## README.md
 ### ✨ Added

--- a/js/app.js
+++ b/js/app.js
@@ -415,7 +415,7 @@ async function main() {
       for (const fox of foxes) {
         fox.userData.mixer.update(0.016);
         fox.position.addScaledVector(fox.userData.direction, fox.userData.speed);
-        fox.position.y = getGroundHeight(fox.position.x, fox.position.z, scene);
+        fox.position.y = getGroundHeight(fox.position.x, fox.position.z);
         fox.rotation.y = Math.atan2(fox.userData.direction.x, fox.userData.direction.z);
         if (Math.random() < 0.01) {
           fox.userData.direction.x += (Math.random() - 0.5) * 0.5;

--- a/js/collision.js
+++ b/js/collision.js
@@ -64,7 +64,7 @@ export function resolvePlayerMovement(pos, movement, velocity, scene, options = 
     checkBlock(block);
   });
 
-  const groundHeight = getGroundHeight(newX, newZ, scene);
+  const groundHeight = getGroundHeight(newX, newZ);
   if (newY <= groundHeight && !standingOnBlock) {
     newY = groundHeight;
     velocity.y = 0;

--- a/js/fox.js
+++ b/js/fox.js
@@ -31,7 +31,7 @@ export async function spawnFoxes(scene, count) {
 
     const x = (Math.random() * 40) - 20;
     const z = (Math.random() * 40) - 20;
-    const y = getGroundHeight(x, z, scene);
+    const y = getGroundHeight(x, z);
     fox.position.set(x, y, z);
 
     fox.userData.mixer = mixer;

--- a/js/worldGeneration.js
+++ b/js/worldGeneration.js
@@ -75,26 +75,13 @@ export class TerrainGenerator {
 
 export let terrainGenerator;
 
-// Get terrain height using a raycaster for better accuracy.
-// Moved from collision.js to be reused here.
-export function getGroundHeight(x, z, scene) {
-  const terrain = scene.children.find(c => c.userData.isTerrain);
-
-  if (terrain) {
-    const raycaster = new THREE.Raycaster();
-    // Start ray from high above. The terrain height is between -25 and 25 approx, so 100 is safe.
-    const rayOrigin = new THREE.Vector3(x, 100, z);
-    const rayDirection = new THREE.Vector3(0, -1, 0);
-    raycaster.set(rayOrigin, rayDirection);
-
-    const intersects = raycaster.intersectObject(terrain);
-
-    if (intersects.length > 0) {
-      return intersects[0].point.y;
-    }
-  }
-
-  // Fallback to procedural generation if terrain mesh not found or no intersection
+// Get terrain height quickly using the same noise generator that built the
+// terrain mesh. This avoids per-frame raycasting which became a bottleneck when
+// multiple animated foxes were added.
+export function getGroundHeight(x, z) {
+  // Using the terrainGenerator directly avoids expensive raycaster calls each
+  // frame. The generator produced the terrain mesh, so its height values match
+  // the rendered ground.
   return terrainGenerator ? terrainGenerator.getHeight(x, z) : 0;
 }
 


### PR DESCRIPTION
## Summary
- make `getGroundHeight` read directly from the terrain generator
- update fox spawning and movement to use new helper
- update collision code
- document change in CHANGELOG

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685b18bf09408332856a901bdbedc3d9